### PR TITLE
This PR adds a volume to the docker compose setup enabling the database to persist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 LICENSE
 README.md
 .vscode/
+db-data/
+nginx/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - POSTGRES_HOST=${POSTGRES_HOST}
       - POSTGRES_PORT=${POSTGRES_PORT}
       - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - ./db-data:/var/lib/postgresql/data
     networks:
       - db_nw
   flaskapp:


### PR DESCRIPTION
This PR has a fix for persisting data across `compose` restarts. Specifically, it does this by mounting postgres' internal data volume to the directory `compose` is ran in.