### PR TITLE
Hosted Documentation via Swagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !docker-compose.yml
 !nginx/flaskapp.conf
 !.env
+!securemailbox/views/docs/*
 
 # Python files
 !*.py

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ flask = "*"
 flask-sqlalchemy = "*"
 flask-migrate = "*"
 psycopg2 = "*"
+flask-swagger = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ flask-sqlalchemy = "*"
 flask-migrate = "*"
 psycopg2 = "*"
 flask-swagger = "*"
+flask-swagger-ui = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e51429229947bfaf1567f67e029e8244049dc3b7a19f1c591ebe39d2e0f5607"
+            "sha256": "edbf076f1a855874485f13226e8e6c4e2b3831bb7ae022208bbbc2516f0613ad"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,13 +21,6 @@
                 "sha256:035ab00497217628bf5d0be82d664d8713ab13d37b630084da8e1f98facf4dbf"
             ],
             "version": "==1.4.2"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
-            ],
-            "version": "==19.3.0"
         },
         "click": {
             "hashes": [
@@ -60,6 +53,14 @@
             "index": "pypi",
             "version": "==2.4.1"
         },
+        "flask-swagger": {
+            "hashes": [
+                "sha256:3caddb1311388eafc86f82f8e64ba386a5df6b84e5f16dfae19ca08173eba216",
+                "sha256:b4085f5bc36df4c20b6548cd1413adc9cf35719b0f0695367cd542065145294d"
+            ],
+            "index": "pypi",
+            "version": "==0.2.14"
+        },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
@@ -69,10 +70,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
-                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "version": "==2.11.1"
+            "version": "==2.11.2"
         },
         "mako": {
             "hashes": [
@@ -119,6 +120,119 @@
             ],
             "version": "==1.1.1"
         },
+        "psycopg2": {
+            "hashes": [
+                "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535",
+                "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7",
+                "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c",
+                "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080",
+                "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81",
+                "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72",
+                "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52",
+                "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e",
+                "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf",
+                "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9",
+                "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb",
+                "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055",
+                "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"
+            ],
+            "index": "pypi",
+            "version": "==2.8.5"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "python-editor": {
+            "hashes": [
+                "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
+                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
+                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"
+            ],
+            "version": "==1.0.4"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+            ],
+            "version": "==5.3.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:083e383a1dca8384d0ea6378bd182d83c600ed4ff4ec8247d3b2442cf70db1ad",
+                "sha256:0a690a6486658d03cc6a73536d46e796b6570ac1f8a7ec133f9e28c448b69828",
+                "sha256:114b6ace30001f056e944cebd46daef38fdb41ebb98f5e5940241a03ed6cad43",
+                "sha256:128f6179325f7597a46403dde0bf148478f868df44841348dfc8d158e00db1f9",
+                "sha256:13d48cd8b925b6893a4e59b2dfb3e59a5204fd8c98289aad353af78bd214db49",
+                "sha256:211a1ce7e825f7142121144bac76f53ac28b12172716a710f4bf3eab477e730b",
+                "sha256:2dc57ee80b76813759cccd1a7affedf9c4dbe5b065a91fb6092c9d8151d66078",
+                "sha256:3e625e283eecc15aee5b1ef77203bfb542563fa4a9aa622c7643c7b55438ff49",
+                "sha256:43078c7ec0457387c79b8d52fff90a7ad352ca4c7aa841c366238c3e2cf52fdf",
+                "sha256:5b1bf3c2c2dca738235ce08079783ef04f1a7fc5b21cf24adaae77f2da4e73c3",
+                "sha256:6056b671aeda3fc451382e52ab8a753c0d5f66ef2a5ccc8fa5ba7abd20988b4d",
+                "sha256:68d78cf4a9dfade2e6cf57c4be19f7b82ed66e67dacf93b32bb390c9bed12749",
+                "sha256:7025c639ce7e170db845e94006cf5f404e243e6fc00d6c86fa19e8ad8d411880",
+                "sha256:7224e126c00b8178dfd227bc337ba5e754b197a3867d33b9f30dc0208f773d70",
+                "sha256:7d98e0785c4cd7ae30b4a451416db71f5724a1839025544b4edbd92e00b91f0f",
+                "sha256:8d8c21e9d4efef01351bf28513648ceb988031be4159745a7ad1b3e28c8ff68a",
+                "sha256:bbb545da054e6297242a1bb1ba88e7a8ffb679f518258d66798ec712b82e4e07",
+                "sha256:d00b393f05dbd4ecd65c989b7f5a81110eae4baea7a6a4cdd94c20a908d1456e",
+                "sha256:e18752cecaef61031252ca72031d4d6247b3212ebb84748fc5d1a0d2029c23ea"
+            ],
+            "version": "==1.3.16"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
+                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+            ],
+            "version": "==1.0.1"
+        }
+    },
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.3"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
@@ -139,25 +253,6 @@
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
             "version": "==0.13.1"
-        },
-        "psycopg2": {
-            "hashes": [
-                "sha256:132efc7ee46a763e68a815f4d26223d9c679953cd190f1f218187cb60decf535",
-                "sha256:2327bf42c1744a434ed8ed0bbaa9168cac7ee5a22a9001f6fc85c33b8a4a14b7",
-                "sha256:27c633f2d5db0fc27b51f1b08f410715b59fa3802987aec91aeb8f562724e95c",
-                "sha256:2c0afb40cfb4d53487ee2ebe128649028c9a78d2476d14a67781e45dc287f080",
-                "sha256:2df2bf1b87305bd95eb3ac666ee1f00a9c83d10927b8144e8e39644218f4cf81",
-                "sha256:440a3ea2c955e89321a138eb7582aa1d22fe286c7d65e26a2c5411af0a88ae72",
-                "sha256:6a471d4d2a6f14c97a882e8d3124869bc623f3df6177eefe02994ea41fd45b52",
-                "sha256:6b306dae53ec7f4f67a10942cf8ac85de930ea90e9903e2df4001f69b7833f7e",
-                "sha256:a0984ff49e176062fcdc8a5a2a670c9bb1704a2f69548bce8f8a7bad41c661bf",
-                "sha256:ac5b23d0199c012ad91ed1bbb971b7666da651c6371529b1be8cbe2a7bf3c3a9",
-                "sha256:acf56d564e443e3dea152efe972b1434058244298a94348fc518d6dd6a9fb0bb",
-                "sha256:d3b29d717d39d3580efd760a9a46a7418408acebbb784717c90d708c9ed5f055",
-                "sha256:f7d46240f7a1ae1dd95aab38bd74f7428d46531f69219954266d669da60c0818"
-            ],
-            "index": "pypi",
-            "version": "==2.8.5"
         },
         "py": {
             "hashes": [
@@ -181,21 +276,6 @@
             "index": "pypi",
             "version": "==5.4.1"
         },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
-                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
-            ],
-            "version": "==2.8.1"
-        },
-        "python-editor": {
-            "hashes": [
-                "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
-                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
-                "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"
-            ],
-            "version": "==1.0.4"
-        },
         "six": {
             "hashes": [
                 "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
@@ -203,26 +283,12 @@
             ],
             "version": "==1.14.0"
         },
-        "sqlalchemy": {
-            "hashes": [
-                "sha256:c4cca4aed606297afbe90d4306b49ad3a4cd36feb3f87e4bfd655c57fd9ef445"
-            ],
-            "version": "==1.3.15"
-        },
         "wcwidth": {
             "hashes": [
                 "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
                 "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
             "version": "==0.1.9"
-        },
-        "werkzeug": {
-            "hashes": [
-                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
-                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
-            ],
-            "version": "==1.0.1"
         }
-    },
-    "develop": {}
+    }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "edbf076f1a855874485f13226e8e6c4e2b3831bb7ae022208bbbc2516f0613ad"
+            "sha256": "0149f9bbb2fbdb59559ea90b4288fa9bd265cde57353efa2712026bc0cdaa07b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -60,6 +60,13 @@
             ],
             "index": "pypi",
             "version": "==0.2.14"
+        },
+        "flask-swagger-ui": {
+            "hashes": [
+                "sha256:42d098997e06b04f992609c4945cc990738b269c153d8388fc59a91a5dfcee9e"
+            ],
+            "index": "pypi",
+            "version": "==3.25.0"
         },
         "itsdangerous": {
             "hashes": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       - ./db-data:/var/lib/postgresql/data
     networks:
       - db_nw
-    ports:
-      - "5432:5432"
   flaskapp:
     build: .
     environment:
@@ -23,8 +21,6 @@ services:
       - web_nw
     depends_on:
       - db
-    ports:
-      - "8082:8082"  
   nginx:
     image: "nginx:latest"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - ./db-data:/var/lib/postgresql/data
     networks:
       - db_nw
+    ports:
+      - "5432:5432"
   flaskapp:
     build: .
     environment:
@@ -21,6 +23,8 @@ services:
       - web_nw
     depends_on:
       - db
+    ports:
+      - "8082:8082"  
   nginx:
     image: "nginx:latest"
     ports:

--- a/securemailbox/__init__.py
+++ b/securemailbox/__init__.py
@@ -1,7 +1,7 @@
-from flask import Flask
+from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-
+from flask_swagger import swagger
 __version__ = "0.8.0"
 
 app = Flask(__name__)
@@ -25,6 +25,13 @@ from securemailbox.views.retrieve import retrieve_blueprint
 app.register_blueprint(register_blueprint)
 app.register_blueprint(send_blueprint)
 app.register_blueprint(retrieve_blueprint)
+
+@app.route("/spec/")
+def spec():
+    swag = swagger(app, from_file_keyword='swagger_from_file')
+    swag['info']['version'] = __version__
+    swag['info']['title'] = "Secure Mailbox"
+    return jsonify(swag)
 
 
 # Create database tables

--- a/securemailbox/__init__.py
+++ b/securemailbox/__init__.py
@@ -23,28 +23,15 @@ migrate = Migrate(app, db)
 from securemailbox.views.register import register_blueprint
 from securemailbox.views.send import send_blueprint
 from securemailbox.views.retrieve import retrieve_blueprint
+from securemailbox.views.docs.spec import spec_blueprint, spec_url
 
 app.register_blueprint(register_blueprint)
 app.register_blueprint(send_blueprint)
 app.register_blueprint(retrieve_blueprint)
+app.register_blueprint(spec_blueprint)
 
-SWAGGER_URL = '/swagger'
-API_URL = '/spec/'
-SWAGGERUI_BLUEPRINT = get_swaggerui_blueprint(
-    SWAGGER_URL,
-    API_URL,
-)
-
-app.register_blueprint(SWAGGERUI_BLUEPRINT, url_prefix=SWAGGER_URL)
-
-
-@app.route("/spec/")
-def spec():
-    swag = swagger(app, from_file_keyword='swagger_from_file')
-    swag['info']['version'] = __version__
-    swag['info']['title'] = "Secure Mailbox"
-    return jsonify(swag)
-
+SWAGGER_URL = "/docs"
+app.register_blueprint(get_swaggerui_blueprint(SWAGGER_URL, spec_url), url_prefix=SWAGGER_URL)
 
 # Create database tables
 # Note: Model classes must be imported prior to this running

--- a/securemailbox/__init__.py
+++ b/securemailbox/__init__.py
@@ -31,7 +31,9 @@ app.register_blueprint(retrieve_blueprint)
 app.register_blueprint(spec_blueprint)
 
 SWAGGER_URL = "/docs"
-app.register_blueprint(get_swaggerui_blueprint(SWAGGER_URL, spec_url), url_prefix=SWAGGER_URL)
+app.register_blueprint(
+    get_swaggerui_blueprint(SWAGGER_URL, spec_url), url_prefix=SWAGGER_URL
+)
 
 # Create database tables
 # Note: Model classes must be imported prior to this running

--- a/securemailbox/__init__.py
+++ b/securemailbox/__init__.py
@@ -4,7 +4,7 @@ from flask_migrate import Migrate
 from flask_swagger import swagger
 from flask_swagger_ui import get_swaggerui_blueprint
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 app = Flask(__name__)
 

--- a/securemailbox/__init__.py
+++ b/securemailbox/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_swagger import swagger

--- a/securemailbox/__init__.py
+++ b/securemailbox/__init__.py
@@ -2,6 +2,8 @@ from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_swagger import swagger
+from flask_swagger_ui import get_swaggerui_blueprint
+
 __version__ = "0.8.0"
 
 app = Flask(__name__)
@@ -25,6 +27,16 @@ from securemailbox.views.retrieve import retrieve_blueprint
 app.register_blueprint(register_blueprint)
 app.register_blueprint(send_blueprint)
 app.register_blueprint(retrieve_blueprint)
+
+SWAGGER_URL = '/swagger'
+API_URL = '/spec/'
+SWAGGERUI_BLUEPRINT = get_swaggerui_blueprint(
+    SWAGGER_URL,
+    API_URL,
+)
+
+app.register_blueprint(SWAGGERUI_BLUEPRINT, url_prefix=SWAGGER_URL)
+
 
 @app.route("/spec/")
 def spec():

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -1,4 +1,4 @@
-Register a Mailbox
+Create a new mailbox
 ---
 tags:
   - API Endpoints
@@ -10,52 +10,43 @@ definitions:
       properties:
         fingerprint:
           type: string
-          description: The fingerprint used to create a new mailbox, must be unique
+          description: An RSA public key fingerprint used to create a new mailbox
   - schema:
-      id: Register Response Success
+      id: Register Response - Success
       properties:
         data:
           nullable: true
-          schema:
-            id: mailbox_fp
-            properties:
-              mailbox:
-                type: string
-                description: The fingerprint of the mailbox created
         error:
-          type: string
+          # type: string
           nullable: true
+
           description: Error message
-        success:
-          type: boolean
-          description: State of successful operation
   - schema:
-      id: Register Response Failure
+      id: Register Response - Failure
       properties:
         error:
           type: string
           description: Error message
-        success:
-          type: boolean
-          description: State of successful operation
+consumes:
+  - application/json
 produces:
   - application/json
 parameters:
-  - in: body
-    name: Register
-    description: Register a mailbox using a fingerprint, fingerprint must be 40 characters and unique.
+  - name: Register
+    in: body
+    description: Create a new mailbox using a fingerprint; fingerprint should be a unique RSA public key fingerprint and 40 characters in length.
     schema:
       $ref: "#/definitions/Register Request"
 responses:
-  200:
+  201:
     description: Mailbox successfully created with given fingerprint
     schema:
-      $ref: "#/definitions/Register Response Success"
+      $ref: "#/definitions/Register Response - Success"
   400:
     description: Unsuccessful creation of mailbox
     schema:
-      $ref: "#/definitions/Register Response Failure"
+      $ref: "#/definitions/Register Response - Failure"
   500:
-    description: Unknown error
+    description: Unsuccessful creation of mailbox due to an unknown error
     schema:
-      $ref: "#/definitions/Register Response Failure"
+      $ref: "#/definitions/Register Response - Failure"

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -10,7 +10,7 @@ definitions:
       properties:
         fingerprint:
           type: string
-          description: An RSA public key fingerprint used to create a new mailbox
+          description: The public key fingerprint used to create a new mailbox
   - schema:
       id: Register Response - Success
       properties:

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -17,7 +17,6 @@ definitions:
         data:
           nullable: true
         error:
-          # type: string
           nullable: true
 
           description: Error message
@@ -32,21 +31,20 @@ consumes:
 produces:
   - application/json
 parameters:
-  - name: Register
-    in: body
+  - in: body
     description: Create a new mailbox using a fingerprint; fingerprint should be a unique RSA public key fingerprint and 40 characters in length.
     schema:
       $ref: "#/definitions/Register Request"
 responses:
   201:
-    description: Mailbox successfully created with given fingerprint
+    description: Mailbox was successfully created with given fingerprint
     schema:
       $ref: "#/definitions/Register Response - Success"
   400:
-    description: Unsuccessful creation of mailbox
+    description: Mailbox was unable to be created
     schema:
       $ref: "#/definitions/Register Response - Failure"
   500:
-    description: Unsuccessful creation of mailbox due to an unknown error
+    description: Mailbox was unable to be created due to an unknown error
     schema:
       $ref: "#/definitions/Register Response - Failure"

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -1,0 +1,47 @@
+Register a Mailbox
+---
+tags:
+  - users
+definitions:
+  - schema:
+      id: Group
+      properties:
+        name:
+         type: string
+         description: the group's name
+parameters:
+  - in: body
+    name: body
+    schema:
+      id: User
+      required:
+        - email
+        - name
+      properties:
+        email:
+          type: string
+          description: email for user
+        name:
+          type: string
+          description: name for user
+        address:
+          description: address for user
+          schema:
+            id: Address
+            properties:
+              street:
+                type: string
+              state:
+                type: string
+              country:
+                type: string
+              postalcode:
+                type: string
+        groups:
+          type: array
+          description: list of groups
+          items:
+            $ref: "#/definitions/Group"
+responses:
+  201:
+    description: User created

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -1,47 +1,63 @@
 Register a Mailbox
 ---
 tags:
-  - users
+  - API Endpoints
 definitions:
   - schema:
-      id: Group
+      id: Register Request
+      required:
+        - fingerprint
       properties:
-        name:
-         type: string
-         description: the group's name
+        fingerprint:
+          type: string
+          minLength: 40
+          maxLength: 40
+          description: The fingerprint used to create a new mailbox, must be 40 characters and unique
+  - schema:
+      id: Register Response Success
+      properties:
+        data:
+          nullable: true
+          schema:
+            id: mailbox_fp
+            properties:
+              mailbox:
+                type: string
+                description: The fingerprint of the mailbox created
+        error:
+          type: string
+          nullable: true
+          description: Error message
+        success:
+          type: boolean
+          description: State of successful operation
+  - schema:
+      id: Register Response Failure
+      properties:
+        error:
+          type: string
+          description: Error message
+        success:
+          type: boolean
+          description: State of successful operation
+produces:
+  - application/json
 parameters:
   - in: body
-    name: body
+    name: Register
+    description: Register a mailbox using a fingerprint, fingerprint must be 40 characters and unique.
     schema:
-      id: User
-      required:
-        - email
-        - name
-      properties:
-        email:
-          type: string
-          description: email for user
-        name:
-          type: string
-          description: name for user
-        address:
-          description: address for user
-          schema:
-            id: Address
-            properties:
-              street:
-                type: string
-              state:
-                type: string
-              country:
-                type: string
-              postalcode:
-                type: string
-        groups:
-          type: array
-          description: list of groups
-          items:
-            $ref: "#/definitions/Group"
+      $ref: "#/definitions/Register Request"
 responses:
-  201:
-    description: User created
+  200:
+    description: Mailbox successfully created with given fingerprint
+    schema:
+      $ref: "#/definitions/Register Response Success"
+  400:
+    description: Unsuccessful creation of mailbox
+    schema:
+      $ref: "#/definitions/Register Response Failure"
+  500:
+    description: Unknown error
+    schema:
+      $ref: "#/definitions/Register Response Failure"

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -10,9 +10,7 @@ definitions:
       properties:
         fingerprint:
           type: string
-          minLength: 40
-          maxLength: 40
-          description: The fingerprint used to create a new mailbox, must be 40 characters and unique
+          description: The fingerprint used to create a new mailbox, must be unique
   - schema:
       id: Register Response Success
       properties:

--- a/securemailbox/views/docs/register.yml
+++ b/securemailbox/views/docs/register.yml
@@ -18,14 +18,22 @@ definitions:
           nullable: true
         error:
           nullable: true
-
-          description: Error message
+          deprecated: True
+          default: null
+        success:
+          type: boolean
+          deprecated: True
+          default: True
   - schema:
       id: Register Response - Failure
       properties:
         error:
           type: string
           description: Error message
+        success:
+          type: boolean
+          deprecated: True
+          default: False
 consumes:
   - application/json
 produces:

--- a/securemailbox/views/docs/retrieve.yml
+++ b/securemailbox/views/docs/retrieve.yml
@@ -48,7 +48,8 @@ definitions:
                 description: Number of messages returned
         error:
           nullable: true
-          description: Error message
+          deprecated: True
+          default: null
         success:
           type: boolean
           deprecated: True

--- a/securemailbox/views/docs/retrieve.yml
+++ b/securemailbox/views/docs/retrieve.yml
@@ -1,4 +1,4 @@
-Retrieve Message Information
+Retrieve messages from a mailbox
 ---
 tags:
   - API Endpoints
@@ -10,65 +10,78 @@ definitions:
       properties:
         fingerprint:
           type: string
-          description: The fingerprint of the mailbox you would like to view messages for
+          description: The public key fingerprint of the mailbox you would like to view messages for
         sender_fingerprint:
           type: string
-          description: Optional additional fingerprint to provide messages from specific sender
+          description: If specified, only get messages from sender with this fingerprint
   - schema:
-      id: Retrieve Response
+      id: Retrieve Response - Success
       properties:
         data:
           nullable: true
           schema:
-            id: messages
+            id: Messages
             properties:
               messages:
                 type: array
-                description: Array of all messages that correspond to the request
+                description: Messages in the mailbox that match the request criteria
                 items:
                   schema:
-                    id: message
+                    id: Message
                     properties:
                       message:
                         type: string
                         description: Message content
                       sender_fingerprint:
                         type: string
-                        description: Fingerprint of the user who sent the message
+                        description: Public key fingerprint of the user who sent the message
                       created_at:
                         type: string
                         format: date-time
-                      updated_at:
-                        type: string
-                        format: date-time
+                      # Removed by sgomena on 5/3 b/c it's not currently applicable
+                      # updated_at:
+                      #   type: string
+                      #   format: date-time
               count:
                 type: integer
-                description: Number of messages
+                min: 0
+                description: Number of messages returned
         error:
-          type: string
           nullable: true
           description: Error message
         success:
           type: boolean
-          description: State of successful operation
+          deprecated: True
+          default: False
+  - schema:
+      id: Retrieve Response - Failure
+      properties:
+        error:
+          type: string
+          description: Error message
+        success:
+          type: boolean
+          deprecated: True
+          default: False
+consumes:
+  - application/json
 produces:
   - application/json
 parameters:
   - in: body
-    name: Retrieve
-    description: Retrieve messages from a mailbox using a fingerprint, limit results to specific sender by providing sender fingerprint
+    description: Retrieve messages from a mailbox using a fingerprint; optionally limit results to specific sender by providing a `sender_fingerprint`
     schema:
       $ref: "#/definitions/Retrieve Request"
 responses:
   200:
-    description: Successfully retrieved messages from desired mailbox
+    description: Messages were succesffully retireved from desired mailbox
     schema:
-      $ref: "#/definitions/Retrieve Response"
+      $ref: "#/definitions/Retrieve Response - Success"
   400:
-    description: Unsuccessful message retrieval
+    description: Messages were unable to be fetched
     schema:
-      $ref: "#/definitions/Retrieve Response"
+      $ref: "#/definitions/Retrieve Response - Failure"
   500:
-    description: Unknown error
+    description: Messages were unable to be fetched due to an unknown error
     schema:
-      $ref: "#/definitions/Retrieve Response"
+      $ref: "#/definitions/Retrieve Response - Failure"

--- a/securemailbox/views/docs/retrieve.yml
+++ b/securemailbox/views/docs/retrieve.yml
@@ -1,47 +1,74 @@
 Retrieve Message Information
 ---
 tags:
-  - users
+  - API Endpoints
 definitions:
   - schema:
-      id: Group
+      id: Retrieve Request
+      required:
+        - fingerprint
       properties:
-        name:
-         type: string
-         description: the group's name
+        fingerprint:
+          type: string
+          description: The fingerprint of the mailbox you would like to view messages for
+        sender_fingerprint:
+          type: string
+          description: Optional additional fingerprint to provide messages from specific sender
+  - schema:
+      id: Retrieve Response
+      properties:
+        data:
+          nullable: true
+          schema:
+            id: messages
+            properties:
+              messages:
+                type: array
+                description: Array of all messages that correspond to the request
+                items:
+                  schema:
+                    id: message
+                    properties:
+                      message:
+                        type: string
+                        description: Message content
+                      sender_fingerprint:
+                        type: string
+                        description: Fingerprint of the user who sent the message
+                      created_at:
+                        type: string
+                        format: date-time
+                      updated_at:
+                        type: string
+                        format: date-time
+              count:
+                type: integer
+                description: Number of messages
+        error:
+          type: string
+          nullable: true
+          description: Error message
+        success:
+          type: boolean
+          description: State of successful operation
+produces:
+  - application/json
 parameters:
   - in: body
-    name: body
+    name: Retrieve
+    description: Retrieve messages from a mailbox using a fingerprint, limit results to specific sender by providing sender fingerprint
     schema:
-      id: User
-      required:
-        - email
-        - name
-      properties:
-        email:
-          type: string
-          description: email for user
-        name:
-          type: string
-          description: name for user
-        address:
-          description: address for user
-          schema:
-            id: Address
-            properties:
-              street:
-                type: string
-              state:
-                type: string
-              country:
-                type: string
-              postalcode:
-                type: string
-        groups:
-          type: array
-          description: list of groups
-          items:
-            $ref: "#/definitions/Group"
+      $ref: "#/definitions/Retrieve Request"
 responses:
-  201:
-    description: User created
+  200:
+    description: Successfully retrieved messages from desired mailbox
+    schema:
+      $ref: "#/definitions/Retrieve Response"
+  400:
+    description: Unsuccessful message retrieval
+    schema:
+      $ref: "#/definitions/Retrieve Response"
+  500:
+    description: Unknown error
+    schema:
+      $ref: "#/definitions/Retrieve Response"

--- a/securemailbox/views/docs/retrieve.yml
+++ b/securemailbox/views/docs/retrieve.yml
@@ -1,0 +1,47 @@
+Retrieve Message Information
+---
+tags:
+  - users
+definitions:
+  - schema:
+      id: Group
+      properties:
+        name:
+         type: string
+         description: the group's name
+parameters:
+  - in: body
+    name: body
+    schema:
+      id: User
+      required:
+        - email
+        - name
+      properties:
+        email:
+          type: string
+          description: email for user
+        name:
+          type: string
+          description: name for user
+        address:
+          description: address for user
+          schema:
+            id: Address
+            properties:
+              street:
+                type: string
+              state:
+                type: string
+              country:
+                type: string
+              postalcode:
+                type: string
+        groups:
+          type: array
+          description: list of groups
+          items:
+            $ref: "#/definitions/Group"
+responses:
+  201:
+    description: User created

--- a/securemailbox/views/docs/retrieve.yml
+++ b/securemailbox/views/docs/retrieve.yml
@@ -75,7 +75,7 @@ parameters:
       $ref: "#/definitions/Retrieve Request"
 responses:
   200:
-    description: Messages were succesffully retireved from desired mailbox
+    description: Messages were successfully retrieved from desired mailbox
     schema:
       $ref: "#/definitions/Retrieve Response - Success"
   400:

--- a/securemailbox/views/docs/send.yml
+++ b/securemailbox/views/docs/send.yml
@@ -1,47 +1,54 @@
 Send a Message
 ---
 tags:
-  - users
+  - API Endpoints
 definitions:
   - schema:
-      id: Group
+      id: Send Request
+      required:
+        - fingerprint
+        - sender_fingerprint
+        - message
       properties:
-        name:
-         type: string
-         description: the group's name
+        fingerprint:
+          type: string
+          description: The fingerprint of the person receiving the message
+        sender_fingerprint:
+          type: string
+          description: The fingerprint of the person sending the message
+        message:
+          type: string
+          description: The message being sent
+  - schema:
+      id: Send Response Success
+      properties:
+        error:
+          type: string
+          nullable: true
+          description: Error message
+        success:
+          type: boolean
+          description: State of successful operation
+  - schema:
+      id: Send Response Failure
+      properties:
+        error:
+          type: string
+          description: Error message
+produces:
+  - application/json
 parameters:
   - in: body
-    name: body
+    name: Send
+    description: Send a message to another user using an existing fingerprint and sender fingerprint.
     schema:
-      id: User
-      required:
-        - email
-        - name
-      properties:
-        email:
-          type: string
-          description: email for user
-        name:
-          type: string
-          description: name for user
-        address:
-          description: address for user
-          schema:
-            id: Address
-            properties:
-              street:
-                type: string
-              state:
-                type: string
-              country:
-                type: string
-              postalcode:
-                type: string
-        groups:
-          type: array
-          description: list of groups
-          items:
-            $ref: "#/definitions/Group"
+      $ref: "#/definitions/Send Request"
 responses:
-  201:
-    description: User created
+  200:
+    description: Message successfully sent
+    schema:
+      $ref: "#/definitions/Send Response Success"
+  400:
+    description: Unsuccessful message sending
+    schema:
+      $ref: "#/definitions/Send Response Failure"

--- a/securemailbox/views/docs/send.yml
+++ b/securemailbox/views/docs/send.yml
@@ -24,8 +24,8 @@ definitions:
       properties:
         error:
           nullable: true
+          deprecated: True
           default: null
-          description: Error message
         success:
           type: boolean
           deprecated: True

--- a/securemailbox/views/docs/send.yml
+++ b/securemailbox/views/docs/send.yml
@@ -1,4 +1,4 @@
-Send a Message
+Send a message to a mailbox
 ---
 tags:
   - API Endpoints
@@ -12,43 +12,53 @@ definitions:
       properties:
         fingerprint:
           type: string
-          description: The fingerprint of the person receiving the message
+          description: The public key fingerprint of the person receiving the message
         sender_fingerprint:
           type: string
-          description: The fingerprint of the person sending the message
+          description: The public key fingerprint of the person sending the message
         message:
           type: string
           description: The message being sent
   - schema:
-      id: Send Response Success
+      id: Send Response - Success
       properties:
         error:
-          type: string
           nullable: true
+          default: null
           description: Error message
         success:
           type: boolean
-          description: State of successful operation
+          deprecated: True
+          default: False
   - schema:
-      id: Send Response Failure
+      id: Send Response - Failure
       properties:
         error:
           type: string
           description: Error message
+        success:
+          type: boolean
+          deprecated: True
+          default: False
+consumes:
+  - application/json
 produces:
   - application/json
 parameters:
   - in: body
-    name: Send
-    description: Send a message to another user using an existing fingerprint and sender fingerprint.
+    description: Send a message to another user's mailbox.
     schema:
       $ref: "#/definitions/Send Request"
 responses:
-  200:
-    description: Message successfully sent
+  201:
+    description: Message was successfully sent
     schema:
-      $ref: "#/definitions/Send Response Success"
+      $ref: "#/definitions/Send Response - Success"
   400:
-    description: Unsuccessful message sending
+    description: Message was not able to be sent
     schema:
-      $ref: "#/definitions/Send Response Failure"
+      $ref: "#/definitions/Send Response - Failure"
+  500:
+    description: Message was not able to be sent due to an unknown error
+    schema:
+      $ref: "#/definitions/Send Response - Failure"

--- a/securemailbox/views/docs/send.yml
+++ b/securemailbox/views/docs/send.yml
@@ -1,0 +1,47 @@
+Send a Message
+---
+tags:
+  - users
+definitions:
+  - schema:
+      id: Group
+      properties:
+        name:
+         type: string
+         description: the group's name
+parameters:
+  - in: body
+    name: body
+    schema:
+      id: User
+      required:
+        - email
+        - name
+      properties:
+        email:
+          type: string
+          description: email for user
+        name:
+          type: string
+          description: name for user
+        address:
+          description: address for user
+          schema:
+            id: Address
+            properties:
+              street:
+                type: string
+              state:
+                type: string
+              country:
+                type: string
+              postalcode:
+                type: string
+        groups:
+          type: array
+          description: list of groups
+          items:
+            $ref: "#/definitions/Group"
+responses:
+  201:
+    description: User created

--- a/securemailbox/views/docs/spec.py
+++ b/securemailbox/views/docs/spec.py
@@ -8,9 +8,10 @@ spec_blueprint = Blueprint("spec", __name__)
 
 spec_url = "/spec/"
 
+
 @spec_blueprint.route(spec_url, methods=["GET"])
 def spec():
-    swag = swagger(app, from_file_keyword='swagger_from_file')
-    swag['info']['version'] = __version__
-    swag['info']['title'] = "Secure Mailboxes API"
+    swag = swagger(app, from_file_keyword="swagger_from_file")
+    swag["info"]["version"] = __version__
+    swag["info"]["title"] = "Secure Mailboxes API"
     return jsonify(swag)

--- a/securemailbox/views/docs/spec.py
+++ b/securemailbox/views/docs/spec.py
@@ -12,5 +12,5 @@ spec_url = "/spec/"
 def spec():
     swag = swagger(app, from_file_keyword='swagger_from_file')
     swag['info']['version'] = __version__
-    swag['info']['title'] = "Secure Mailbox"
+    swag['info']['title'] = "Secure Mailboxes API"
     return jsonify(swag)

--- a/securemailbox/views/docs/spec.py
+++ b/securemailbox/views/docs/spec.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, jsonify
+from flask_swagger import swagger
+
+from securemailbox import app, __version__
+
+# Create the 'spec' blueprint
+spec_blueprint = Blueprint("spec", __name__)
+
+spec_url = "/spec/"
+
+@spec_blueprint.route(spec_url, methods=["GET"])
+def spec():
+    swag = swagger(app, from_file_keyword='swagger_from_file')
+    swag['info']['version'] = __version__
+    swag['info']['title'] = "Secure Mailbox"
+    return jsonify(swag)

--- a/securemailbox/views/register.py
+++ b/securemailbox/views/register.py
@@ -29,10 +29,18 @@ def register():
                 jsonify({"success": False, "error": f"field '{field}' is required."}),
                 400,
             )
-        # Error if fingerprint is not a valid length 
-        if field_to_check == "fingerprint" and len(field_to_check) != FINGERPRINT_LENGTH:
+        # Error if fingerprint is not a valid length
+        if (
+            field_to_check == "fingerprint"
+            and len(field_to_check) != FINGERPRINT_LENGTH
+        ):
             return (
-                jsonify({"success": False, "error": f"field '{field}' is not a valid length."}),
+                jsonify(
+                    {
+                        "success": False,
+                        "error": f"field '{field}' is not a valid length.",
+                    }
+                ),
                 400,
             )
     try:
@@ -41,7 +49,7 @@ def register():
         db.session.add(new_mailbox)
         db.session.commit()
 
-        # If successful creation return 201 CREATED 
+        # If successful creation return 201 CREATED
         return (
             jsonify({"success": True, "error": None, "data": None}),
             201,

--- a/securemailbox/views/register.py
+++ b/securemailbox/views/register.py
@@ -29,7 +29,8 @@ def register():
                 jsonify({"success": False, "error": f"field '{field}' is required."}),
                 400,
             )
-        if len(field_to_check) != FINGERPRINT_LENGTH:
+        # Error if fingerprint is not a valid length 
+        if field_to_check == "fingerprint" and len(field_to_check) != FINGERPRINT_LENGTH:
             return (
                 jsonify({"success": False, "error": f"field '{field}' is not a valid length."}),
                 400,
@@ -40,9 +41,10 @@ def register():
         db.session.add(new_mailbox)
         db.session.commit()
 
+        # If successful creation return 201 CREATED 
         return (
-            jsonify({"success": True, "error": None, "data": {"mailbox": new_mailbox.fingerprint}}),
-            200,
+            jsonify({"success": True, "error": None, "data": None}),
+            201,
         )
     except IntegrityError:
         return (

--- a/securemailbox/views/register.py
+++ b/securemailbox/views/register.py
@@ -12,6 +12,11 @@ register_blueprint = Blueprint("register", __name__)
 
 @register_blueprint.route("/register/", methods=["POST"])
 def register():
+    """
+    Register a Mailbox
+    
+    swagger_from_file: securemailbox/views/docs/register.yml
+    """
     # Ensure a valid request is received
     if not request.is_json:
         return jsonify({"success": False, "error": "Request must be valid json"}), 400

--- a/securemailbox/views/retrieve.py
+++ b/securemailbox/views/retrieve.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, jsonify, request, json
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
-from flask_swagger import swagger
 
 from ..models import Mailbox
 from ..models import Message

--- a/securemailbox/views/retrieve.py
+++ b/securemailbox/views/retrieve.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request, json
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
+from flask_swagger import swagger
 
 from ..models import Mailbox
 from ..models import Message
@@ -10,9 +11,14 @@ from securemailbox import db
 # Create the `retrieve` blueprint
 retrieve_blueprint = Blueprint("retrieve", __name__)
 
-
 @retrieve_blueprint.route("/retrieve/", methods=["POST"])
 def retrieve():
+
+    """
+    Retrieve Message Information
+
+    swagger_from_file: securemailbox/views/docs/retrieve.yml
+    """
 
     # Check for valid json request
     if not request.is_json:

--- a/securemailbox/views/retrieve.py
+++ b/securemailbox/views/retrieve.py
@@ -108,7 +108,8 @@ def retrieve():
                 "message": message.message,
                 "sender_fingerprint": message.sender_fingerprint,
                 "created_at": message.created_at,
-                "updated_at": message.updated_at,
+                # Removed by sgomena on 5/3 b/c it's not currently applicable
+                # "updated_at": message.updated_at,
             }
         )
 

--- a/securemailbox/views/retrieve.py
+++ b/securemailbox/views/retrieve.py
@@ -10,6 +10,7 @@ from securemailbox import db
 # Create the `retrieve` blueprint
 retrieve_blueprint = Blueprint("retrieve", __name__)
 
+
 @retrieve_blueprint.route("/retrieve/", methods=["POST"])
 def retrieve():
 
@@ -50,7 +51,9 @@ def retrieve():
 
     # search for fingerprint in mailbox table
     try:
-        mailbox_id = db.session.query(Mailbox.id).filter_by(fingerprint=req_fingerprint).first()
+        mailbox_id = (
+            db.session.query(Mailbox.id).filter_by(fingerprint=req_fingerprint).first()
+        )
     except NoResultFound:
         return (
             jsonify(

--- a/securemailbox/views/send.py
+++ b/securemailbox/views/send.py
@@ -14,7 +14,11 @@ send_blueprint = Blueprint("send", __name__)
 
 @send_blueprint.route("/send/", methods=["POST"])
 def send():
-
+    """
+    Send a Message
+    
+    swagger_from_file: securemailbox/views/docs/send.yml
+    """
     #get fingerprint
     fingerprint = request.json.get("fingerprint", None)
     if fingerprint is None:

--- a/securemailbox/views/send.py
+++ b/securemailbox/views/send.py
@@ -63,7 +63,7 @@ def send():
         db.session.add(message_ob)
         db.session.commit()
 
-        return jsonify({"success": True, data: None}), 201
+        return jsonify({"success": True, "error": None, data: None}), 201
     except DBAPIError:
         return (
             jsonify({"success": False, "error": "message failed to add to messages"}),

--- a/securemailbox/views/send.py
+++ b/securemailbox/views/send.py
@@ -22,13 +22,13 @@ def send():
     #get fingerprint
     fingerprint = request.json.get("fingerprint", None)
     if fingerprint is None:
-        return jsonify({"error": "no fingerprint"}), 400
+        return jsonify({"success": False, "error": "no fingerprint"}), 400
     sender_fingerprint = request.json.get("sender_fingerprint", None)
     if sender_fingerprint is None:
-        return jsonify({"error": "no send fingerprint"}), 400
+        return jsonify({"success": False, "error": "no send fingerprint"}), 400
     message_t = request.json.get("message", None)
     if message_t is None:
-        return jsonify({"error": "no message"}), 400
+        return jsonify({"success": False, "error": "no message"}), 400
     
     #update messages associated
     try:
@@ -42,23 +42,20 @@ def send():
         mailbox_send_id = None
     #validity
     if mailbox_id is None:
-        return jsonify({"error": "no recipient fingerprint match"}), 400
+        return jsonify({"success": False, "error": "no recipient fingerprint match"}), 400
     if mailbox_send_id is None:
-        return jsonify({"error": "no sender fingerprint match"}), 400
-
-    
-
-    #dont need this
-    #mail = Message.query.filter_by(mailbox_id=mailbox_id)
+        return jsonify({"success": False, "error": "no sender fingerprint match"}), 400
     
     try:
         message_ob = Message(message=message_t,sender_fingerprint=sender_fingerprint, mailbox_id=mailbox_id)
         db.session.add(message_ob)
         db.session.commit()
-    except DBAPIError:
-        return jsonify({"error": "message failed to add to messages"}), 400
-    
-    return jsonify({"success": True, "error": None})
 
-#messages in a mailbox instance is where message is added
-#to what I have now implies message not within mailbox needs modification
+        return jsonify({"success": True, data: None}), 201
+    except DBAPIError:
+        return jsonify({"success": False, "error": "message failed to add to messages"}), 400
+    
+    # Catch all; there was an unknown error
+    except BaseException as e:
+        return jsonify({"success": False, "error": repr(e)}), 500
+

--- a/test_app.py
+++ b/test_app.py
@@ -16,4 +16,5 @@ def test_register(client):
         "/register/", json={"fingerprint": "FAC10F0C3D1D49F8F9A82CB553E79F7C92E1CF32"}
     )
     json_data = rv.get_json()
-    assert json_data == {"success": True, "error": None, "data": {"mailbox": "FAC10F0C3D1D49F8F9A82CB553E79F7C92E1CF32"}}
+    assert rv.status_code == 201
+    assert json_data == {"success": True, "error": None, "data": None}


### PR DESCRIPTION
This PR adds:
- Generated documentation available at `/docs/`

This PR changes:
- Creating mailboxes and messages (via `/register/` and `/send/`, respectively) now return `201 CREATED` on success.
- Removes `updated_at` field of messages. See #39 
- Formats with black

This PR deprecates:
- `success` field in both successful and unsuccessful responses
- `error` field in successful responses